### PR TITLE
update zeppelin to use 0.7.2 package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ bash:
 
 run:
 	docker build -t zeppelin ./zeppelin/.
-	docker run -it --rm --net spark-net -p 80:8080 -v $(shell pwd)/notebook:/opt/zeppelin/notebook -v $(shell pwd)/zeppelin-0.7.1-bin-all:/opt/zeppelin zeppelin /bin/bash
+	docker run -it --rm --net spark-net -p 80:8080 -v $(shell pwd)/notebook:/opt/zeppelin/notebook -v $(shell pwd)/zeppelin-0.7.2-bin-all:/opt/zeppelin zeppelin /bin/bash
 	#docker run -it --rm --net spark-net -p 80:8080 -v $(shell pwd)/notebook:/opt/zeppelin/notebook zeppelin /opt/zeppelin/bin/zeppelin.sh
 
 build:

--- a/zeppelin/Dockerfile
+++ b/zeppelin/Dockerfile
@@ -3,11 +3,11 @@ MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 
 ENV APACHE_SPARK_VERSION 2.1.0
 ENV APACHE_HADOOP_VERSION 2.8.0
-ENV ZEPPELIN_VERSION 0.7.1
+ENV ZEPPELIN_VERSION 0.7.2
 
 RUN apt-get update && apt-get install wget
 RUN set -x \
-    && curl -fSL "http://www-eu.apache.org/dist/zeppelin/zeppelin-0.7.1/zeppelin-0.7.1-bin-all.tgz" -o /tmp/zeppelin.tgz \
+    && curl -fSL "http://www-eu.apache.org/dist/zeppelin/zeppelin-0.7.2/zeppelin-0.7.2-bin-all.tgz" -o /tmp/zeppelin.tgz \
     && tar -xzvf /tmp/zeppelin.tgz -C /opt/ \
     && mv /opt/zeppelin-* /opt/zeppelin \
     && rm /tmp/zeppelin.tgz


### PR DESCRIPTION
Update Zeppelin to  use 0.7.2 instead of the previous 0.7.1